### PR TITLE
Add script to harvest via flashbots [WIP]

### DIFF
--- a/contracts-draft/BadgerTreeV2.sol
+++ b/contracts-draft/BadgerTreeV2.sol
@@ -246,7 +246,7 @@ contract BadgerTreeV2 is Initializable, AccessControlUpgradeable, ICumulativeMul
     function _setClaimed(
         address token,
         address account,
-        unit256 amount
+        uint256 amount
     ) internal {
         claimed[account][token] = claimed[account][token].add(amount);
     }

--- a/contracts-draft/badger-sett/MEVBriber.sol
+++ b/contracts-draft/badger-sett/MEVBriber.sol
@@ -2,11 +2,14 @@
 
 pragma solidity ^0.6.0;
 
+// import "deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
 import "deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "interfaces/badger/IBadgerRewardsManager.sol";
 
 contract MEVBriber is AccessControlUpgradeable, ReentrancyGuardUpgradeable {
+    // using SafeMathUpgradeable for uint256;
     IBadgerRewardsManager rewardsManager;
+    bytes32 public constant KEEPER_ROLE = keccak256("KEEPER_ROLE");
 
     function initialize(
         address admin,
@@ -38,7 +41,7 @@ contract MEVBriber is AccessControlUpgradeable, ReentrancyGuardUpgradeable {
         require(harvested >= minHarvest, "Want harvested is too low");
 
         // Ref: https://docs.flashbots.net/flashbots-auction/searchers/advanced/coinbase-payment/#managing-payments-to-coinbaseaddress-when-it-is-a-contract
-        block.coinbase.call{value: msg.value}();
+        block.coinbase.call{value: msg.value}(new bytes(0));
         // block.coinbase.transfer(msg.value);
     }
 }

--- a/contracts-draft/badger-sett/MEVBriber.sol
+++ b/contracts-draft/badger-sett/MEVBriber.sol
@@ -3,32 +3,21 @@
 pragma solidity ^0.6.0;
 
 import "deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "interfaces/badger/IAccessControl.sol";
+import "interfaces/badger/IBadgerRewardsManager.sol";
 
 contract MEVBriber is AccessControlUpgradeable, ReentrancyGuardUpgradeable {
-    IAccessControl rewardsManager;
+    IBadgerRewardsManager rewardsManager;
 
-    // TODO: Share definition by moving to library (or abstract contract)
-    uint256 private constant MAX_SWAPS = 3; // Memory arrays are fixed size in solidity
-    struct HarvestData {
-        uint256 badgerHarvested;
-        uint256 totalBadger;
-        uint256 badgerConvertedToWbtc;
-        uint256 wbtcFromConversion;
-        uint256 lpGained;
-        uint256 lpDeposited;
-        // Swapped tokens
-        address[MAX_SWAPS] swappedTokenAddressesIn;
-        address[MAX_SWAPS] swappedTokenAddressesOut;
-        uint256[MAX_SWAPS] swappedTokenAmountsIn;
-        uint256[MAX_SWAPS] swappedTokenAmountsOut;
-    }
-
-    function initialize(address initialKeeper, address _rewardsManager) public initializer {
+    function initialize(
+        address admin,
+        address initialKeeper,
+        address _rewardsManager
+    ) public initializer {
         __AccessControl_init();
 
+        _setupRole(DEFAULT_ADMIN_ROLE, admin);
         _setupRole(KEEPER_ROLE, initialKeeper);
-        rewardsManager = IAccessControl(_rewardsManager);
+        rewardsManager = IBadgerRewardsManager(_rewardsManager);
     }
 
     /// ===== Modifiers =====
@@ -38,37 +27,15 @@ contract MEVBriber is AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     }
 
     // * @param strategy Address of strategy to harvest
-    // * @param swappedTokensIn Address of tokens which are swapped from during harvest
-    // * @param swappedTokensOut Address of tokens which are swapped into during harvest
-    // * @param minSwapPrices 10^18 * Minimum expected price from swap
-    function privateHarvest(
-        address strategy,
-        address[] memory swappedTokensIn,
-        address[] memory swappedTokensOut,
-        uint256[] memory minSwapPrices
-    ) external payable nonReentrant {
+    // * @param minHarvest Min amount of want expected to be harvested
+    function privateHarvest(address strategy, uint256 minHarvest) external payable nonReentrant {
         _onlyKeeper();
-
-        require(
-            (swappedTokensIn.length == swappedTokensOut.length) && (swappedTokensIn.length == minAmountExpectedAfterSwap.length),
-            "swappedTokensIn, swappedTokensOut and minAmountExpectedAfterSwap must have same length"
-        );
 
         // Redundant since it's checked in BadgerRewardsManager harvest(). Maybe remove?
         // require(rewardsManager.hasRole(rewardsManager.KEEPER_ROLE, msg.sender), "Must have keeper role");
 
-        // TODO: HarvestData struct is not standard across all strategies. Either standarize or return tuple
-        HarvestData harvestData = rewardsManager.harvest(strategy);
-
-        for (uint256 i = 0; i < swappedTokensIn.length; i++) {
-            // Order of tokens is important
-            require(harvestData.swappedTokenAddressesIn[i] == swappedTokensIn[i], "Swapped tokens inputs must match");
-            require(harvestData.swappedTokenAddressesOut[i] == swappedTokensOut[i], "Swapped tokens outputs must match");
-
-            // Check if slippage is within bounds
-            uint256 minOutExpected = harvestData.swappedTokenAmountsIn[i].mul(minSwapPrices[i]).div(1e18);
-            require(harvestData.swappedTokenAmountsOut[i] >= minOutExpected, "Token amount after swap is too low");
-        }
+        uint256 harvested = rewardsManager.harvest(strategy);
+        require(harvested >= minHarvest, "Want harvested is too low");
 
         // Ref: https://docs.flashbots.net/flashbots-auction/searchers/advanced/coinbase-payment/#managing-payments-to-coinbaseaddress-when-it-is-a-contract
         block.coinbase.call{value: msg.value}();

--- a/contracts-draft/badger-sett/MEVBriber.sol
+++ b/contracts-draft/badger-sett/MEVBriber.sol
@@ -5,23 +5,73 @@ pragma solidity ^0.6.0;
 import "deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "interfaces/badger/IAccessControl.sol";
 
-contract MEVBriber is OwnableUpgradeable {
+contract MEVBriber is AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     IAccessControl rewardsManager;
 
-    function initialize(address _rewardsManager) public initializer {
-        __Ownable_init();
+    // TODO: Share definition by moving to library (or abstract contract)
+    uint256 private constant MAX_SWAPS = 3; // Memory arrays are fixed size in solidity
+    struct HarvestData {
+        uint256 badgerHarvested;
+        uint256 totalBadger;
+        uint256 badgerConvertedToWbtc;
+        uint256 wbtcFromConversion;
+        uint256 lpGained;
+        uint256 lpDeposited;
+        // Swapped tokens
+        address[MAX_SWAPS] swappedTokenAddressesIn;
+        address[MAX_SWAPS] swappedTokenAddressesOut;
+        uint256[MAX_SWAPS] swappedTokenAmountsIn;
+        uint256[MAX_SWAPS] swappedTokenAmountsOut;
+    }
+
+    function initialize(address initialKeeper, address _rewardsManager) public initializer {
+        __AccessControl_init();
+
+        _setupRole(KEEPER_ROLE, initialKeeper);
         rewardsManager = IAccessControl(_rewardsManager);
     }
 
-    function briber(address[] memory targets, bytes[] memory data) external payable {
-        require(targets.length == data.length, "targets and data must have same length");
-        require(rewardsManager.hasRole(rewardsManager.KEEPER_ROLE, msg.sender), "Must have keeper role");
+    /// ===== Modifiers =====
 
-        for (uint256 i = 0; i < targets.length; i++) {
-            (bool _success, ) = _targets[i].call(_data[i]);
-            require(_success);
+    function _onlyKeeper() internal view {
+        require(hasRole(KEEPER_ROLE, msg.sender), "KEEPER_ROLE");
+    }
+
+    // * @param strategy Address of strategy to harvest
+    // * @param swappedTokensIn Address of tokens which are swapped from during harvest
+    // * @param swappedTokensOut Address of tokens which are swapped into during harvest
+    // * @param minSwapPrices 10^18 * Minimum expected price from swap
+    function privateHarvest(
+        address strategy,
+        address[] memory swappedTokensIn,
+        address[] memory swappedTokensOut,
+        uint256[] memory minSwapPrices
+    ) external payable nonReentrant {
+        _onlyKeeper();
+
+        require(
+            (swappedTokensIn.length == swappedTokensOut.length) && (swappedTokensIn.length == minAmountExpectedAfterSwap.length),
+            "swappedTokensIn, swappedTokensOut and minAmountExpectedAfterSwap must have same length"
+        );
+
+        // Redundant since it's checked in BadgerRewardsManager harvest(). Maybe remove?
+        // require(rewardsManager.hasRole(rewardsManager.KEEPER_ROLE, msg.sender), "Must have keeper role");
+
+        // TODO: HarvestData struct is not standard across all strategies. Either standarize or return tuple
+        HarvestData harvestData = rewardsManager.harvest(strategy);
+
+        for (uint256 i = 0; i < swappedTokensIn.length; i++) {
+            // Order of tokens is important
+            require(harvestData.swappedTokenAddressesIn[i] == swappedTokensIn[i], "Swapped tokens inputs must match");
+            require(harvestData.swappedTokenAddressesOut[i] == swappedTokensOut[i], "Swapped tokens outputs must match");
+
+            // Check if slippage is within bounds
+            uint256 minOutExpected = harvestData.swappedTokenAmountsIn[i].mul(minSwapPrices[i]).div(1e18);
+            require(harvestData.swappedTokenAmountsOut[i] >= minOutExpected, "Token amount after swap is too low");
         }
 
+        // Ref: https://docs.flashbots.net/flashbots-auction/searchers/advanced/coinbase-payment/#managing-payments-to-coinbaseaddress-when-it-is-a-contract
         block.coinbase.call{value: msg.value}();
+        // block.coinbase.transfer(msg.value);
     }
 }

--- a/contracts-draft/badger-sett/MEVBriber.sol
+++ b/contracts-draft/badger-sett/MEVBriber.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "interfaces/badger/IAccessControl.sol";
+
+contract MEVBriber is OwnableUpgradeable {
+    IAccessControl rewardsManager;
+
+    function initialize(address _rewardsManager) public initializer {
+        __Ownable_init();
+        rewardsManager = IAccessControl(_rewardsManager);
+    }
+
+    function briber(address[] memory targets, bytes[] memory data) external payable {
+        require(targets.length == data.length, "targets and data must have same length");
+        require(rewardsManager.hasRole(rewardsManager.KEEPER_ROLE, msg.sender), "Must have keeper role");
+
+        for (uint256 i = 0; i < targets.length; i++) {
+            (bool _success, ) = _targets[i].call(_data[i]);
+            require(_success);
+        }
+
+        block.coinbase.call{value: msg.value}();
+    }
+}

--- a/contracts/badger-sett/BadgerRewardsManager.sol
+++ b/contracts/badger-sett/BadgerRewardsManager.sol
@@ -140,7 +140,7 @@ contract BadgerRewardsManager is AccessControlUpgradeable, ReentrancyGuardUpgrad
         IStrategy(strategy).tend();
     }
 
-    function harvest(address strategy) external {
+    function harvest(address strategy) external returns (uint256) {
         _onlyKeeper();
         _onlyApprovedStrategies(strategy);
 

--- a/contracts/badger-sett/BadgerRewardsManager.sol
+++ b/contracts/badger-sett/BadgerRewardsManager.sol
@@ -144,7 +144,7 @@ contract BadgerRewardsManager is AccessControlUpgradeable, ReentrancyGuardUpgrad
         _onlyKeeper();
         _onlyApprovedStrategies(strategy);
 
-        IStrategy(strategy).harvest();
+        return IStrategy(strategy).harvest();
     }
 
     // ===== Permissioned Functions: Swapper =====

--- a/contracts/badger-sett/strategies/uni/StrategyBadgerLpMetaFarm.sol
+++ b/contracts/badger-sett/strategies/uni/StrategyBadgerLpMetaFarm.sol
@@ -47,6 +47,7 @@ contract StrategyBadgerLpMetaFarm is BaseStrategyMultiSwapper {
         uint256 blockNumber
     );
 
+    uint256 private constant MAX_SWAPS = 3; // Memory arrays are fixed size in solidity
     struct HarvestData {
         uint256 badgerHarvested;
         uint256 totalBadger;
@@ -54,6 +55,11 @@ contract StrategyBadgerLpMetaFarm is BaseStrategyMultiSwapper {
         uint256 wbtcFromConversion;
         uint256 lpGained;
         uint256 lpDeposited;
+        // Swapped tokens
+        address[MAX_SWAPS] swappedTokenAddressesIn;
+        address[MAX_SWAPS] swappedTokenAddressesOut;
+        uint256[MAX_SWAPS] swappedTokenAmountsIn;
+        uint256[MAX_SWAPS] swappedTokenAmountsOut;
     }
 
     function initialize(
@@ -153,7 +159,15 @@ contract StrategyBadgerLpMetaFarm is BaseStrategyMultiSwapper {
                 path[0] = badger; // Badger
                 path[1] = wbtc;
 
+                // TODO: Maybe make swap return amount received from swap
+                uint256 _beforeWbtc = IERC20Upgradeable(wbtc).balanceOf(address(this));
                 _swap(badger, harvestData.badgerConvertedToWbtc, path);
+                uint256 _afterWbtc = IERC20Upgradeable(wbtc).balanceOf(address(this));
+
+                harvestData.swappedTokenAddressesIn[0] = badger;
+                harvestData.swappedTokenAddressesOut[0] = wbtc;
+                harvestData.swappedTokenAmountsIn[0] = harvestData.badgerConvertedToWbtc;
+                harvestData.swappedTokenAmountsOut[0] = _afterWbtc.sub(_beforeWbtc);
 
                 // Add Badger and wBTC as liquidity if any to add
                 _add_max_liquidity_uniswap(badger, wbtc);

--- a/helpers/flashbots_utils.py
+++ b/helpers/flashbots_utils.py
@@ -89,13 +89,5 @@ def estimate_briber_gas_cost(badger: BadgerSystem, strategy, overrides):
     """
     Estimate gas cost for calling harvest through briber.
     """
-    harvest_data = strategy.harvest.call(overrides)
-
-    tokens_in = harvest_data.swappedTokenAddressesIn
-    tokens_out = harvest_data.swappedTokenAddressesOut
-    min_prices = [0] * len(tokens_in)
-
-    gas_estimate = badger.mevBriber.privateHarvest.estimate_gas(
-        strategy, tokens_in, tokens_out, min_prices, overrides
-    )
+    gas_estimate = badger.mevBriber.privateHarvest.estimate_gas(strategy, 0, overrides)
     return gas_strategies.gas_cost(gas_estimate)

--- a/helpers/flashbots_utils.py
+++ b/helpers/flashbots_utils.py
@@ -15,74 +15,14 @@ def is_supported(key):
     return key in {"native.uniBadgerWbtc"}
 
 
-def get_min_price_for_swap(sellToken, buyToken, sellAmount, slippage=None):
+def get_min_expected_harvest(strategy, key, overrides):
     """
-    Get minimum swap price based on slippage tolerance.
-    """
-    # TODO: This doesn't work either. Find an API for off-chain price for BADGER-WBTC
-    try:
-        get_price(sellToken, buyToken, sellAmount)
-    except ValueError:
-        endpoint = "https://api.1inch.exchange/v3.0/"
-
-        params = (
-            str(web3.chain_id)  # TODO: Maybe move to network_manager
-            + "/quote?fromTokenAddress="
-            + sellToken
-            + "&toTokenAddress="
-            + buyToken
-            + "&amount="
-            + str(sellAmount)
-        )
-        r = requests.get(endpoint + params)
-        data = r.json()
-
-        if not data.get("toTokenAmount"):
-            console.log(data)
-            raise ValueError("Price could not be fetched")
-
-        return data["toTokenAmount"] / data["fromTokenAmount"]
-
-
-def get_harvest_swap_expected(strategy, key, overrides):
-    """
-    Return swaps expected in strategy harvest() call and corresponding guaranteed swap prices.
+    Return minimum expected harvest from strategy.
     """
     assert is_supported(key)
 
-    harvest_data = strategy.harvest.call(overrides)
-    num_swaps = len(harvest_data.swappedTokenAddressesIn)
-    return {
-        "tokensIn": harvest_data.swappedTokenAddressesIn,
-        "tokensOut": harvest_data.swappedTokenAddressesOut,
-        "minPrices": [
-            get_min_price_for_swap(
-                harvest_data.swappedTokenAddressesIn[i],
-                harvest_data.swappedTokenAddressesOut[i],
-                harvest_data.swappedTokenAmountsIn[i],
-            )
-            for i in range(num_swaps)
-        ],
-    }
-
-
-def get_harvest_swap_expected_array(strategy, key, overrides):
-    assert is_supported(key)
-
-    harvest_data = strategy.harvest.call(overrides)
-    num_swaps = len(harvest_data.swappedTokenAddressesIn)
-    return [
-        {
-            "tokenIn": harvest_data.swappedTokenAddressesIn[i],
-            "tokenOut": harvest_data.swappedTokenAddressesOut[i],
-            "minPrice": get_min_price_for_swap(
-                harvest_data.swappedTokenAddressesIn[i],
-                harvest_data.swappedTokenAddressesOut[i],
-                harvest_data.swappedTokenAmountsIn[i],
-            ),
-        }
-        for i in range(num_swaps)
-    ]
+    # TODO: Get pending rewards and convert to want using price API
+    pass
 
 
 def estimate_briber_gas_cost(badger: BadgerSystem, strategy, overrides):

--- a/helpers/flashbots_utils.py
+++ b/helpers/flashbots_utils.py
@@ -1,0 +1,101 @@
+from brownie import *
+from helpers.gas_utils import gas_strategies
+from helpers.sett.strategy_earnings import (
+    get_price,
+)
+from rich.console import Console
+from scripts.systems.badger_system import BadgerSystem
+import requests
+
+console = Console()
+
+
+def is_supported(key):
+    # TODO: Currently only supports native.uniBadgerWbtc
+    return key in {"native.uniBadgerWbtc"}
+
+
+def get_min_price_for_swap(sellToken, buyToken, sellAmount, slippage=None):
+    """
+    Get minimum swap price based on slippage tolerance.
+    """
+    # TODO: This doesn't work either. Find an API for off-chain price for BADGER-WBTC
+    try:
+        get_price(sellToken, buyToken, sellAmount)
+    except ValueError:
+        endpoint = "https://api.1inch.exchange/v3.0/"
+
+        params = (
+            str(web3.chain_id)  # TODO: Maybe move to network_manager
+            + "/quote?fromTokenAddress="
+            + sellToken
+            + "&toTokenAddress="
+            + buyToken
+            + "&amount="
+            + str(sellAmount)
+        )
+        r = requests.get(endpoint + params)
+        data = r.json()
+
+        if not data.get("toTokenAmount"):
+            console.log(data)
+            raise ValueError("Price could not be fetched")
+
+        return data["toTokenAmount"] / data["fromTokenAmount"]
+
+
+def get_harvest_swap_expected(strategy, key, overrides):
+    """
+    Return swaps expected in strategy harvest() call and corresponding guaranteed swap prices.
+    """
+    assert is_supported(key)
+
+    harvest_data = strategy.harvest.call(overrides)
+    num_swaps = len(harvest_data.swappedTokenAddressesIn)
+    return {
+        "tokensIn": harvest_data.swappedTokenAddressesIn,
+        "tokensOut": harvest_data.swappedTokenAddressesOut,
+        "minPrices": [
+            get_min_price_for_swap(
+                harvest_data.swappedTokenAddressesIn[i],
+                harvest_data.swappedTokenAddressesOut[i],
+                harvest_data.swappedTokenAmountsIn[i],
+            )
+            for i in range(num_swaps)
+        ],
+    }
+
+
+def get_harvest_swap_expected_array(strategy, key, overrides):
+    assert is_supported(key)
+
+    harvest_data = strategy.harvest.call(overrides)
+    num_swaps = len(harvest_data.swappedTokenAddressesIn)
+    return [
+        {
+            "tokenIn": harvest_data.swappedTokenAddressesIn[i],
+            "tokenOut": harvest_data.swappedTokenAddressesOut[i],
+            "minPrice": get_min_price_for_swap(
+                harvest_data.swappedTokenAddressesIn[i],
+                harvest_data.swappedTokenAddressesOut[i],
+                harvest_data.swappedTokenAmountsIn[i],
+            ),
+        }
+        for i in range(num_swaps)
+    ]
+
+
+def estimate_briber_gas_cost(badger: BadgerSystem, strategy, overrides):
+    """
+    Estimate gas cost for calling harvest through briber.
+    """
+    harvest_data = strategy.harvest.call(overrides)
+
+    tokens_in = harvest_data.swappedTokenAddressesIn
+    tokens_out = harvest_data.swappedTokenAddressesOut
+    min_prices = [0] * len(tokens_in)
+
+    gas_estimate = badger.mevBriber.privateHarvest.estimate_gas(
+        strategy, tokens_in, tokens_out, min_prices, overrides
+    )
+    return gas_strategies.gas_cost(gas_estimate)

--- a/helpers/sett/SnapshotManager.py
+++ b/helpers/sett/SnapshotManager.py
@@ -37,7 +37,7 @@ from helpers.sett.strategy_earnings import (
 )
 from helpers.flashbots_utils import (
     estimate_briber_gas_cost,
-    get_harvest_swap_expected,
+    get_min_expected_harvest,
 )
 from helpers.tx_timer import tx_timer
 from helpers.gas_utils import gas_strategies
@@ -246,17 +246,13 @@ class SnapshotManager:
         trackedUsers = {"user": user}
         before = self.snap(trackedUsers)
 
-        # swap_data = get_harvest_swap_expected(strategy, overrides)
+        min_harvested = get_min_expected_harvest(strategy, overrides)
 
         tx_timer.start_timer(overrides["from"], "Harvest")
         # Create transaction data
         tx = self.badger.mevBriber.functions.privateHarvest(
             strategy,
-            # swap_data["tokensIn"],
-            # swap_data["tokensOut"],
-            # str(
-            #     int(1e18 * swap_data["minPrices"])
-            # ),  # TODO: Check if the format is fine
+            min_harvested,
         ).buildTransaction(overrides)
 
         signed_tx = overrides["from"].sign_transaction(tx)

--- a/helpers/sett/SnapshotManager.py
+++ b/helpers/sett/SnapshotManager.py
@@ -246,17 +246,17 @@ class SnapshotManager:
         trackedUsers = {"user": user}
         before = self.snap(trackedUsers)
 
-        swap_data = get_harvest_swap_expected(strategy, overrides)
+        # swap_data = get_harvest_swap_expected(strategy, overrides)
 
         tx_timer.start_timer(overrides["from"], "Harvest")
         # Create transaction data
         tx = self.badger.mevBriber.functions.privateHarvest(
             strategy,
-            swap_data["tokensIn"],
-            swap_data["tokensOut"],
-            str(
-                int(1e18 * swap_data["minPrices"])
-            ),  # TODO: Check if the format is fine
+            # swap_data["tokensIn"],
+            # swap_data["tokensOut"],
+            # str(
+            #     int(1e18 * swap_data["minPrices"])
+            # ),  # TODO: Check if the format is fine
         ).buildTransaction(overrides)
 
         signed_tx = overrides["from"].sign_transaction(tx)
@@ -267,7 +267,7 @@ class SnapshotManager:
         ]
 
         # Flashbots bundles target a specific block
-        block_number = web3.eth.blockNumber + 3
+        block_number = web3.eth.blockNumber + 1
         result = web3.flashbots.send_bundle(bundle, target_block_number=block_number)
         console.log(
             "bundle broadcasted at block:",
@@ -409,7 +409,7 @@ class SnapshotManager:
             )
             bribe = miner_tip + gas_cost
 
-            earnings = get_harvest_earnings(self.strategy, key, overrides)
+            earnings = get_harvest_earnings(self.strategy, key, overrides) # Requires BADGER-WBTC price
             if earnings == "skip":
                 return min_profit
 

--- a/helpers/sett/strategy_earnings.py
+++ b/helpers/sett/strategy_earnings.py
@@ -95,7 +95,7 @@ def get_harvest_earnings(strategy: Contract, key: str, overrides):
         crv_gauge = Contract.from_explorer(strategy.gauge())
         earnings = crv_gauge.claimable_tokens.call(strategy.address, overrides)
 
-    elif is_xsushi_strategy(key) or is_pancake_strategy(key):
+    elif is_xsushi_strategy(key) or is_pancake_strategy(key) or is_badger_strategy(key):
         harvest_data = strategy.harvest.call(overrides)
         earnings = harvest_data[0]
 
@@ -108,22 +108,24 @@ def get_harvest_earnings(strategy: Contract, key: str, overrides):
     return calc_profit(earnings, token_address, token)
 
 
-def get_price(token: str, sellAmount=1000000000000000000):
+def get_price(token: str, buyToken: str = None, sellAmount=1000000000000000000):
     """
     get_price uses the 0x api to get the most accurate eth price for the token
 
     :param token: token ticker or token address
-    :param buyToken: token to denominate price in, default is WETH
+    :param buyToken: token to denominate price in, default is WETH/WBNB
     :param sellAmount: token amount to sell in base unit, default is 1e18
-    :return: eth/bnb price per token for the specified amount to sell
+    :return: buyToken price per sellToken for the specified amount to sell
     """
 
     if curr_network == "bsc" or curr_network == "bsc-fork":
         endpoint = "https://bsc.api.0x.org/"
-        buyToken = "WBNB"
+        if buyToken is None:
+            buyToken = "WBNB"
     elif curr_network == "eth":
         endpoint = "https://api.0x.org/"
-        buyToken = "WETH"
+        if buyToken is None:
+            buyToken = "WETH"
     else:
         raise ValueError("Unrecognized network")
 

--- a/interfaces/badger/IBadgerRewardsManager.sol
+++ b/interfaces/badger/IBadgerRewardsManager.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IBadgerRewardsManager {
+    function deposit(address strategy) external;
+
+    // TODO: Maybe return uint256 here as well if we want to check later
+    function tend(address strategy) external;
+
+    function harvest(address strategy) external returns (uint256);
+}

--- a/interfaces/badger/IStrategy.sol
+++ b/interfaces/badger/IStrategy.sol
@@ -19,7 +19,9 @@ interface IStrategy {
     function withdrawAll() external returns (uint256);
 
     function balanceOf() external view returns (uint256);
+
     function balanceOfPool() external view returns (uint256);
+
     function balanceOfWant() external view returns (uint256);
 
     function getName() external pure returns (string memory);
@@ -42,5 +44,5 @@ interface IStrategy {
 
     function tend() external;
 
-    function harvest() external;
+    function harvest() external returns (uint256);
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,6 +89,7 @@ vvm==0.1.0
 vyper==0.2.12
 wcwidth==0.2.5
 web3==5.18.0
+git+https://github.com/shuklaayush/web3-flashbots.git@master
 websockets==8.1
 yarl==1.6.3
 matplotlib==3.4.2

--- a/scripts/keeper/flashbots/harvest_flashbots.py
+++ b/scripts/keeper/flashbots/harvest_flashbots.py
@@ -1,28 +1,32 @@
-import os
-
 from brownie import *
 from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
-from web3.contract import estimate_gas_for_function
-from web3.middleware import construct_sign_and_send_raw_middleware
 from config.keeper import keeper_config
 from flashbots import flashbot
-from flashbots.types import SignTx
+from helpers.flashbots_utils import estimate_briber_gas_cost
 from helpers.gas_utils import gas_strategies
-from helpers.registry import registry
 from helpers.sett.SnapshotManager import SnapshotManager
-from helpers.utils import tx_wait, val
+from helpers.utils import tx_wait
 from helpers.console_utils import console
 from scripts.systems.badger_system import BadgerSystem, connect_badger
-from tabulate import tabulate
-from web3.types import TxParams, Wei
+from web3.types import Wei
 
 gas_strategies.set_default_for_active_chain()
 
-ETH_ACCOUNT_SIGNATURE = Account.from_key(
-    os.environ.get("ETH_SIGNATURE_KEY")
-)
-flashbot(web3, ETH_ACCOUNT_SIGNATURE)
+# Account which signifies your identify to flashbots network
+FLASHBOTS_SIGNER: LocalAccount = accounts.load("flashbots-signer")
+flashbot(web3, FLASHBOTS_SIGNER)
+
+# Extra tip to pay Flashbots miner for tx
+miner_tip = web3.toWei("0.01", "ether")
+
+
+def has_briber_support(strategy_key):
+    """
+    Check if strategy supports harvesting through briber
+    """
+    return strategy_key in {"native.uniBadgerWbtc"}
+
 
 def harvest_all(badger: BadgerSystem, skip, min_profit=0):
     """
@@ -30,11 +34,12 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
     If a profit estimate fails for any reason the default behavior is to treat it as having a profit of zero.
 
     :param badger: badger system
+    :param strategies: strategies to include in the harvest
     :param skip: strategies to skip checking
     :param min_profit: minimum estimated profit (in ETH or BNB) required for harvest to be executed on chain
     """
     for key, vault in badger.sett_system.vaults.items():
-        if key in skip:
+        if not has_briber_support(key) or key in skip:
             continue
 
         console.print(
@@ -48,25 +53,29 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
 
         before = snap.snap()
         if strategy.keeper() == badger.badgerRewardsManager:
+            # TODO: This should be keeper of BadgerRewardsManager
             keeper = accounts.at(strategy.keeper())
-            estimated_profit = snap.estimateProfitHarvestViaManager(
+            # TODO: Why pass key/strategy if SnapshotManager has self.strategy?
+            estimated_profit = snap.estimateProfitHarvestViaManagerThroughFlashbots(
                 key,
                 strategy,
                 {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+                min_profit,
+                web3.fromWei(miner_tip, "ether"),
             )
             if estimated_profit >= min_profit:
-                snap.settHarvestViaManager(
+                gas_cost = estimate_briber_gas_cost(badger, strategy)
+                bribe = miner_tip + gas_cost
+
+                snap.settHarvestViaManagerThroughFlashbots(
                     strategy,
-                    {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
-                    confirm=False,
-                )
-        else:
-            estimated_profit = snap.estimateProfitHarvest(
-                key, {"from": keeper, "gas_limit": 2000000, "allow_revert": True}
-            )
-            if estimated_profit >= min_profit:
-                snap.settHarvest(
-                    {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+                    {
+                        "from": keeper,
+                        "value": bribe,
+                        "gas_limit": 2000000,
+                        "gas_price": 0,
+                        "allow_revert": True,  # TODO: Not sure if this is needed
+                    },
                     confirm=False,
                 )
 
@@ -96,4 +105,4 @@ def main():
         skip.append("experimental.sushiIBbtcWbtc")
         skip.append("experimental.digg")
 
-    harvest_all(badger, skip)
+    harvest_all(badger, skip, miner_tip=miner_tip)

--- a/scripts/keeper/flashbots/harvest_flashbots.py
+++ b/scripts/keeper/flashbots/harvest_flashbots.py
@@ -1,0 +1,99 @@
+import os
+
+from brownie import *
+from eth_account.account import Account
+from eth_account.signers.local import LocalAccount
+from web3.contract import estimate_gas_for_function
+from web3.middleware import construct_sign_and_send_raw_middleware
+from config.keeper import keeper_config
+from flashbots import flashbot
+from flashbots.types import SignTx
+from helpers.gas_utils import gas_strategies
+from helpers.registry import registry
+from helpers.sett.SnapshotManager import SnapshotManager
+from helpers.utils import tx_wait, val
+from helpers.console_utils import console
+from scripts.systems.badger_system import BadgerSystem, connect_badger
+from tabulate import tabulate
+from web3.types import TxParams, Wei
+
+gas_strategies.set_default_for_active_chain()
+
+ETH_ACCOUNT_SIGNATURE = Account.from_key(
+    os.environ.get("ETH_SIGNATURE_KEY")
+)
+flashbot(web3, ETH_ACCOUNT_SIGNATURE)
+
+def harvest_all(badger: BadgerSystem, skip, min_profit=0):
+    """
+    Runs harvest function for strategies if they are expected to be profitable.
+    If a profit estimate fails for any reason the default behavior is to treat it as having a profit of zero.
+
+    :param badger: badger system
+    :param skip: strategies to skip checking
+    :param min_profit: minimum estimated profit (in ETH or BNB) required for harvest to be executed on chain
+    """
+    for key, vault in badger.sett_system.vaults.items():
+        if key in skip:
+            continue
+
+        console.print(
+            "\n[bold yellow]===== Harvest: " + str(key) + " =====[/bold yellow]\n"
+        )
+
+        print("Harvest: " + key)
+
+        snap = SnapshotManager(badger, key)
+        strategy = badger.getStrategy(key)
+
+        before = snap.snap()
+        if strategy.keeper() == badger.badgerRewardsManager:
+            keeper = accounts.at(strategy.keeper())
+            estimated_profit = snap.estimateProfitHarvestViaManager(
+                key,
+                strategy,
+                {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+            )
+            if estimated_profit >= min_profit:
+                snap.settHarvestViaManager(
+                    strategy,
+                    {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+                    confirm=False,
+                )
+        else:
+            estimated_profit = snap.estimateProfitHarvest(
+                key, {"from": keeper, "gas_limit": 2000000, "allow_revert": True}
+            )
+            if estimated_profit >= min_profit:
+                snap.settHarvest(
+                    {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+                    confirm=False,
+                )
+
+        tx_wait()
+
+        if rpc.is_active():
+            chain.mine()
+        after = snap.snap()
+
+        snap.printCompare(before, after)
+
+
+def main():
+    badger = connect_badger(load_keeper=True, load_harvester=True)
+    skip = keeper_config.get_active_chain_skipped_setts("harvest")
+
+    if rpc.is_active():
+        """
+        Test: Load up testing accounts with ETH
+        """
+        accounts[0].transfer(badger.deployer, Wei("5 ether"))
+        accounts[0].transfer(badger.keeper, Wei("5 ether"))
+        accounts[0].transfer(badger.guardian, Wei("5 ether"))
+
+        skip.append("native.test")
+        skip.append("yearn.wbtc")
+        skip.append("experimental.sushiIBbtcWbtc")
+        skip.append("experimental.digg")
+
+    harvest_all(badger, skip)

--- a/scripts/keeper/flashbots/harvest_flashbots.py
+++ b/scripts/keeper/flashbots/harvest_flashbots.py
@@ -53,16 +53,17 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
 
         before = snap.snap()
         if strategy.keeper() == badger.badgerRewardsManager:
-            # TODO: This should be keeper of BadgerRewardsManager
-            keeper = accounts.at(strategy.keeper())
-            # TODO: Why pass key/strategy if SnapshotManager has self.strategy?
-            estimated_profit = snap.estimateProfitHarvestViaManagerThroughFlashbots(
-                key,
-                strategy,
-                {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
-                min_profit,
-                web3.fromWei(miner_tip, "ether"),
-            )
+            keeper = badger.harvester # Use the harvester account if we have the choice
+
+            ## TODO: Why pass key/strategy if SnapshotManager has self.strategy?
+            # estimated_profit = snap.estimateProfitHarvestViaManagerThroughFlashbots(
+            #     key,
+            #     strategy,
+            #     {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+            #     min_profit,
+            #     web3.fromWei(miner_tip, "ether"),
+            # )
+            estimated_profit = 1
             if estimated_profit >= min_profit:
                 gas_cost = estimate_briber_gas_cost(badger, strategy)
                 bribe = miner_tip + gas_cost

--- a/scripts/keeper/harvest.py
+++ b/scripts/keeper/harvest.py
@@ -35,7 +35,7 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
 
         before = snap.snap()
         if strategy.keeper() == badger.badgerRewardsManager:
-            keeper = badger.harvester # Use the harvester account if we have the choice
+            keeper = badger.harvester  # Use the harvester account if we have the choice
             # estimated_profit = snap.estimateProfitHarvestViaManager(
             #     key,
             #     strategy,

--- a/scripts/keeper/harvest.py
+++ b/scripts/keeper/harvest.py
@@ -16,7 +16,6 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
     """
     Runs harvest function for strategies if they are expected to be profitable.
     If a profit estimate fails for any reason the default behavior is to treat it as having a profit of zero.
-
     :param badger: badger system
     :param skip: strategies to skip checking
     :param min_profit: minimum estimated profit (in ETH or BNB) required for harvest to be executed on chain
@@ -36,13 +35,13 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
 
         before = snap.snap()
         if strategy.keeper() == badger.badgerRewardsManager:
-            keeper = accounts.at(strategy.keeper())
-            estimated_profit = snap.estimateProfitHarvestViaManager(
-                key,
-                strategy,
-                {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
-                min_profit,
-            )
+            keeper = badger.harvester # Use the harvester account if we have the choice
+            # estimated_profit = snap.estimateProfitHarvestViaManager(
+            #     key,
+            #     strategy,
+            #     {"from": keeper, "gas_limit": 2000000, "allow_revert": True}
+            # )
+            estimated_profit = 1
             if estimated_profit >= min_profit:
                 snap.settHarvestViaManager(
                     strategy,
@@ -50,11 +49,12 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
                     confirm=False,
                 )
         else:
-            estimated_profit = snap.estimateProfitHarvest(
-                key,
-                {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
-                min_profit,
-            )
+            keeper = accounts.at(strategy.keeper())
+            # estimated_profit = snap.estimateProfitHarvest(
+            #     key,
+            #     {"from": keeper, "gas_limit": 2000000, "allow_revert": True}
+            # )
+            estimated_profit = 1
             if estimated_profit >= min_profit:
                 snap.settHarvest(
                     {"from": keeper, "gas_limit": 2000000, "allow_revert": True},

--- a/scripts/systems/badger_system.py
+++ b/scripts/systems/badger_system.py
@@ -260,6 +260,8 @@ def connect_badger(
         badger.connect_governance_timelock(badger_deploy["timelock"])
     if "badgerRewardsManager" in badger_deploy:
         badger.connect_rewards_manager(badger_deploy["badgerRewardsManager"])
+    if "mevBriber" in badger_deploy:
+        badger.connect_mev_briber(badger_deploy["mevBriber"])
     if "unlockScheduler" in badger_deploy:
         badger.connect_unlock_scheduler(badger_deploy["unlockScheduler"])
     if "rewardsLogger" in badger_deploy:
@@ -1350,6 +1352,10 @@ class BadgerSystem:
         self.track_contract_upgradeable(
             "badgerRewardsManager", self.badgerRewardsManager
         )
+
+    def connect_mev_briber(self, address):
+        self.mevBriber = MEVBriber.at(address)
+        self.track_contract_upgradeable("mevBriber", self.mevBriber)
 
     def connect_unlock_scheduler(self, address):
         self.unlockScheduler = UnlockScheduler.at(address)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ settsToRun = [
     # "native.sbtcCrv",
     # "native.tbtcCrv",
     # "harvest.renCrv",
-    # "native.uniBadgerWbtc",
+    "native.uniBadgerWbtc",
     # "native.sushiBadgerWbtc",
     # "native.sushiWbtcEth",
     # "native.sushiWbtcIbBtc",

--- a/tests/sett/test_flashbots.py
+++ b/tests/sett/test_flashbots.py
@@ -1,0 +1,25 @@
+import pytest
+
+from brownie import *
+from dotmap import DotMap
+from helpers.sett.SnapshotManager import SnapshotManager
+from tests.conftest import badger_single_sett, settTestConfig
+
+
+# @pytest.mark.skip()
+@pytest.mark.parametrize(
+    "settConfig",
+    settTestConfig,
+)
+def test_mev_briber(settConfig):
+    print(settConfig)
+    badger = badger_single_sett(settConfig)
+    strategy = badger.getStrategy(settConfig["id"])
+
+    # Deploy MEVBriber
+    deployer = accounts[0]
+    keeper = accounts[2]
+
+    briber = MEVBriber.deploy({"from": deployer})
+    briber.intialize(deployer, keeper, badger.badgerRewardsManager)
+    mevBriber.privateHarvest(strategy, 0, {"value": web3.toWei("0.01", "ether")})

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,6 +251,76 @@
     patch-package "^6.2.2"
     postinstall-postinstall "^2.1.0"
 
+"@ethereumjs/block@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.4.0.tgz#4747b0c06220ee10cbdfe1cbde8cbb0677b1b074"
+  integrity sha512-umKAoTX32yXzErpIksPHodFc/5y8bmZMnOl6hWy5Vd8xId4+HKFUOyEiN16Y97zMwFRysRpcrR6wBejfqc6Bmg==
+  dependencies:
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/tx" "^3.3.0"
+    ethereumjs-util "^7.1.0"
+    merkle-patricia-tree "^4.2.0"
+
+"@ethereumjs/blockchain@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.4.0.tgz#28d712627d3442b2bb1f50dd5acba7cde1021993"
+  integrity sha512-wAuKLaew6PL52kH8YPXO7PbjjKV12jivRSyHQehkESw4slSLLfYA6Jv7n5YxyT2ajD7KNMPVh7oyF/MU6HcOvg==
+  dependencies:
+    "@ethereumjs/block" "^3.4.0"
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/ethash" "^1.0.0"
+    debug "^2.2.0"
+    ethereumjs-util "^7.1.0"
+    level-mem "^5.0.1"
+    lru-cache "^5.1.1"
+    rlp "^2.2.4"
+    semaphore-async-await "^1.5.1"
+
+"@ethereumjs/common@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.4.0.tgz#2d67f6e6ba22246c5c89104e6b9a119fb3039766"
+  integrity sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.0"
+
+"@ethereumjs/ethash@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/ethash/-/ethash-1.0.0.tgz#4e77f85b37be1ade5393e8719bdabac3e796ddaa"
+  integrity sha512-iIqnGG6NMKesyOxv2YctB2guOVX18qMAWlj3QlZyrc+GqfzLqoihti+cVNQnyNxr7eYuPdqwLQOFuPe6g/uKjw==
+  dependencies:
+    "@types/levelup" "^4.3.0"
+    buffer-xor "^2.0.1"
+    ethereumjs-util "^7.0.7"
+    miller-rabin "^4.0.0"
+
+"@ethereumjs/tx@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.0.tgz#14ed1b7fa0f28e1cd61e3ecbdab824205f6a4378"
+  integrity sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==
+  dependencies:
+    "@ethereumjs/common" "^2.4.0"
+    ethereumjs-util "^7.1.0"
+
+"@ethereumjs/vm@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.5.0.tgz#d389c5792320ef28c51366a643b8ab9d64e10a31"
+  integrity sha512-h6Kr6WqKUP8nVuEzCWPWEPrC63v7HFwt3gRuK7CJiyg9S0iWSBKUA/YVD4YgaSVACuxUfWaOBbwV5uGVupm5PQ==
+  dependencies:
+    "@ethereumjs/block" "^3.4.0"
+    "@ethereumjs/blockchain" "^5.4.0"
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/tx" "^3.3.0"
+    async-eventemitter "^0.2.4"
+    core-js-pure "^3.0.1"
+    debug "^2.2.0"
+    ethereumjs-util "^7.1.0"
+    functional-red-black-tree "^1.0.1"
+    mcl-wasm "^0.7.1"
+    merkle-patricia-tree "^4.2.0"
+    rustbn.js "~0.2.0"
+    util.promisify "^1.0.1"
+
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"
@@ -296,6 +366,21 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/abi@^5.1.2":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.0.tgz#a6d63bdb3672f738398846d4279fa6b6c9818242"
+  integrity sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@ethersproject/abstract-provider@5.0.7", "@ethersproject/abstract-provider@^5.0.4":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.7.tgz#04ee3bfe43323384e7fecf6c774975b8dec4bdc9"
@@ -309,6 +394,19 @@
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/web" "^5.0.6"
 
+"@ethersproject/abstract-provider@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz#415331031b0f678388971e1987305244edc04e1d"
+  integrity sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+
 "@ethersproject/abstract-signer@5.0.9", "@ethersproject/abstract-signer@^5.0.4", "@ethersproject/abstract-signer@^5.0.6":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.9.tgz#238ddc06031aeb9dfceee2add965292d7dd1acbf"
@@ -319,6 +417,17 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
+
+"@ethersproject/abstract-signer@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz#cd5f50b93141ee9f9f49feb4075a0b3eafb57d65"
+  integrity sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
 
 "@ethersproject/address@5.0.8", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.0.5":
   version "5.0.8"
@@ -331,12 +440,30 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/rlp" "^5.0.3"
 
+"@ethersproject/address@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.4.0.tgz#ba2d00a0f8c4c0854933b963b9a3a9f6eb4a37a3"
+  integrity sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+
 "@ethersproject/base64@5.0.6", "@ethersproject/base64@^5.0.3":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.6.tgz#26311ebf29ea3d0b9c300ccf3e1fdc44b7481516"
   integrity sha512-HwrGn8YMiUf7bcdVvB4NJ+eWT0BtEFpDtrYxVXEbR7p/XBSJjwiR7DEggIiRvxbualMKg+EZijQWJ3az2li0uw==
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
+
+"@ethersproject/base64@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
+  integrity sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
 
 "@ethersproject/basex@5.0.6", "@ethersproject/basex@^5.0.3":
   version "5.0.6"
@@ -355,6 +482,15 @@
     "@ethersproject/logger" "^5.0.5"
     bn.js "^4.4.0"
 
+"@ethersproject/bignumber@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.0.tgz#be8dea298c0ec71208ee60f0b245be0761217ad9"
+  integrity sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    bn.js "^4.11.9"
+
 "@ethersproject/bytes@5.0.8", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.0.8":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.8.tgz#cf1246a6a386086e590063a4602b1ffb6cc43db1"
@@ -362,12 +498,26 @@
   dependencies:
     "@ethersproject/logger" "^5.0.5"
 
+"@ethersproject/bytes@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
+  integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
 "@ethersproject/constants@5.0.7", "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.0.4":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.7.tgz#44ff979e5781b17c8c6901266896c3ee745f4e7e"
   integrity sha512-cbQK1UpE4hamB52Eg6DLhJoXeQ1plSzekh5Ujir1xdREdwdsZPPXKczkrWqBBR0KyywJZHN/o/hj0w8j7scSGg==
   dependencies:
     "@ethersproject/bignumber" "^5.0.7"
+
+"@ethersproject/constants@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
+  integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
 
 "@ethersproject/contracts@5.0.8":
   version "5.0.8"
@@ -397,6 +547,20 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.4"
     "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/hash@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
+  integrity sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
 
 "@ethersproject/hdnode@5.0.7", "@ethersproject/hdnode@^5.0.4":
   version "5.0.7"
@@ -443,10 +607,23 @@
     "@ethersproject/bytes" "^5.0.4"
     js-sha3 "0.5.7"
 
+"@ethersproject/keccak256@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
+  integrity sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    js-sha3 "0.5.7"
+
 "@ethersproject/logger@5.0.8", "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.0.5":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.8.tgz#135c1903d35c878265f3cbf2b287042c4c20d5d4"
   integrity sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==
+
+"@ethersproject/logger@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.0.tgz#f39adadf62ad610c420bcd156fd41270e91b3ca9"
+  integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
 
 "@ethersproject/networks@5.0.6", "@ethersproject/networks@^5.0.3":
   version "5.0.6"
@@ -454,6 +631,13 @@
   integrity sha512-2Cg1N5109zzFOBfkyuPj+FfF7ioqAsRffmybJ2lrsiB5skphIAE72XNSCs4fqktlf+rwSh/5o/UXRjXxvSktZw==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/networks@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.4.1.tgz#2ce83b8e42aa85216e5d277a7952d97b6ce8d852"
+  integrity sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
 
 "@ethersproject/pbkdf2@5.0.6", "@ethersproject/pbkdf2@^5.0.3":
   version "5.0.6"
@@ -469,6 +653,13 @@
   integrity sha512-a9DUMizYhJ0TbtuDkO9iYlb2CDlpSKqGPDr+amvlZhRspQ6jbl5Eq8jfu4SCcGlcfaTbguJmqGnyOGn1EFt6xA==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/properties@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.0.tgz#38ba20539b44dcc5d5f80c45ad902017dcdbefe7"
+  integrity sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
 
 "@ethersproject/providers@5.0.17":
   version "5.0.17"
@@ -511,6 +702,14 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
 
+"@ethersproject/rlp@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.4.0.tgz#de61afda5ff979454e76d3b3310a6c32ad060931"
+  integrity sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
 "@ethersproject/sha2@5.0.6", "@ethersproject/sha2@^5.0.3":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.0.6.tgz#175116dc10b866a0a381f6316d094bcc510bee3c"
@@ -529,6 +728,18 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
     elliptic "6.5.3"
+
+"@ethersproject/signing-key@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.4.0.tgz#2f05120984e81cf89a3d5f6dec5c68ee0894fbec"
+  integrity sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
 
 "@ethersproject/solidity@5.0.7":
   version "5.0.7"
@@ -550,6 +761,15 @@
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
 
+"@ethersproject/strings@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
+  integrity sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
 "@ethersproject/transactions@5.0.8", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.0.5":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.0.8.tgz#3b4d7041e13b957a9c4f131e0aea9dae7b6f5a23"
@@ -564,6 +784,21 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/rlp" "^5.0.3"
     "@ethersproject/signing-key" "^5.0.4"
+
+"@ethersproject/transactions@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.4.0.tgz#a159d035179334bd92f340ce0f77e83e9e1522e0"
+  integrity sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
 
 "@ethersproject/units@5.0.8":
   version "5.0.8"
@@ -606,6 +841,17 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/web@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.4.0.tgz#49fac173b96992334ed36a175538ba07a7413d1f"
+  integrity sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==
+  dependencies:
+    "@ethersproject/base64" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@ethersproject/wordlists@5.0.7", "@ethersproject/wordlists@^5.0.4":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.0.7.tgz#4e5ad38cfbef746b196a3290c0d41696eb7ab468"
@@ -643,27 +889,6 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
-
-"@nomiclabs/ethereumjs-vm@^4.1.1":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz#a853bdb4fb032529f810f32bb767551d19d7ce57"
-  integrity sha512-+XwqoO941bILTO4KDLIUJ37U42ySxw6it7jyoi0tKv0/VUcOrWKF1TCQWMv6dBDRlxpPQd273n9o5SVlYYLRWQ==
-  dependencies:
-    async "^2.1.2"
-    async-eventemitter "^0.2.2"
-    core-js-pure "^3.0.1"
-    ethereumjs-account "^3.0.0"
-    ethereumjs-block "^2.2.2"
-    ethereumjs-blockchain "^4.0.3"
-    ethereumjs-common "^1.5.0"
-    ethereumjs-tx "^2.1.2"
-    ethereumjs-util "^6.2.0"
-    fake-merkle-patricia-tree "^1.0.1"
-    functional-red-black-tree "^1.0.1"
-    merkle-patricia-tree "^2.3.2"
-    rustbn.js "~0.2.0"
-    safe-buffer "^5.1.1"
-    util.promisify "^1.0.0"
 
 "@nomiclabs/hardhat-ethers@^2.0.0":
   version "2.0.1"
@@ -951,10 +1176,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@solidity-parser/parser@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.7.1.tgz#660210130e4237476cb55e2882064809f80f861e"
-  integrity sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw==
+"@solidity-parser/parser@^0.11.0":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.1.tgz#fa840af64840c930f24a9c82c08d4a092a068add"
+  integrity sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ==
 
 "@solidity-parser/parser@^0.8.1":
   version "0.8.1"
@@ -985,6 +1210,11 @@
     tmp "^0.2.1"
     utf-8-validate "^5.0.2"
     ws "^7.4.2"
+
+"@types/abstract-leveldown@*":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.2.tgz#ee81917fe38f770e29eec8139b6f16ee4a8b0a5f"
+  integrity sha512-+jA1XXF3jsz+Z7FcuiNqgK53hTa/luglT2TyTpKPqoYbxVY+mCPF22Rm+q3KPBrMHJwNXFrTViHszBOfU4vftQ==
 
 "@types/bchaddrjs@^0.4.0":
   version "0.4.0"
@@ -1053,6 +1283,20 @@
   resolved "https://registry.yarnpkg.com/@types/keccak/-/keccak-3.0.1.tgz#1dfad12395f32927cf409707534dd796d57aa84c"
   integrity sha512-/MxAVmtyyeOvZ6dGf3ciLwFRuV5M8DRIyYNFGHYI6UyBW4/XqyO0LZw+JFMvaeY3cHItQAkELclBU1x5ank6mg==
   dependencies:
+    "@types/node" "*"
+
+"@types/level-errors@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/level-errors/-/level-errors-3.0.0.tgz#15c1f4915a5ef763b51651b15e90f6dc081b96a8"
+  integrity sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==
+
+"@types/levelup@^4.3.0":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/levelup/-/levelup-4.3.3.tgz#4dc2b77db079b1cf855562ad52321aa4241b8ef4"
+  integrity sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==
+  dependencies:
+    "@types/abstract-leveldown" "*"
+    "@types/level-errors" "*"
     "@types/node" "*"
 
 "@types/lru-cache@^5.1.0":
@@ -1240,11 +1484,33 @@ abstract-leveldown@^5.0.0, abstract-leveldown@~5.0.0:
   dependencies:
     xtend "~4.0.0"
 
+abstract-leveldown@^6.2.1:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz#d25221d1e6612f820c35963ba4bd739928f6026a"
+  integrity sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==
+  dependencies:
+    buffer "^5.5.0"
+    immediate "^3.2.3"
+    level-concat-iterator "~2.0.0"
+    level-supports "~1.0.0"
+    xtend "~4.0.0"
+
 abstract-leveldown@~2.6.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz#1c5e8c6a5ef965ae8c35dfb3a8770c476b82c4b8"
   integrity sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==
   dependencies:
+    xtend "~4.0.0"
+
+abstract-leveldown@~6.2.1:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz#036543d87e3710f2528e47040bc3261b77a9a8eb"
+  integrity sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==
+  dependencies:
+    buffer "^5.5.0"
+    immediate "^3.2.3"
+    level-concat-iterator "~2.0.0"
+    level-supports "~1.0.0"
     xtend "~4.0.0"
 
 accepts@~1.3.7:
@@ -1501,7 +1767,7 @@ async-each@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-eventemitter@^0.2.2:
+async-eventemitter@^0.2.2, async-eventemitter@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/async-eventemitter/-/async-eventemitter-0.2.4.tgz#f5e7c8ca7d3e46aab9ec40a292baf686a0bafaca"
   integrity sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==
@@ -2472,7 +2738,7 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -3255,6 +3521,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -3537,6 +3811,14 @@ deferred-leveldown@~4.0.0:
     abstract-leveldown "~5.0.0"
     inherits "^2.0.3"
 
+deferred-leveldown@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz#27a997ad95408b61161aa69bd489b86c71b78058"
+  integrity sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==
+  dependencies:
+    abstract-leveldown "~6.2.1"
+    inherits "^2.0.3"
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -3722,6 +4004,19 @@ elliptic@6.5.3, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elliptic@6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 elliptic@=3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-3.0.3.tgz#865c9b420bfbe55006b9f969f97a0d2c44966595"
@@ -3775,6 +4070,16 @@ encoding-down@5.0.4, encoding-down@~5.0.0:
     level-codec "^9.0.0"
     level-errors "^2.0.0"
     xtend "^4.0.1"
+
+encoding-down@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/encoding-down/-/encoding-down-6.3.0.tgz#b1c4eb0e1728c146ecaef8e32963c549e76d082b"
+  integrity sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==
+  dependencies:
+    abstract-leveldown "^6.2.1"
+    inherits "^2.0.3"
+    level-codec "^9.0.0"
+    level-errors "^2.0.0"
 
 encoding@^0.1.11:
   version "0.1.13"
@@ -4179,7 +4484,7 @@ ethereumjs-account@^2.0.3:
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-block@2.2.2, ethereumjs-block@^2.2.0, ethereumjs-block@^2.2.2, ethereumjs-block@~2.2.0, ethereumjs-block@~2.2.2:
+ethereumjs-block@2.2.2, ethereumjs-block@^2.2.2, ethereumjs-block@~2.2.0, ethereumjs-block@~2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz#c7654be7e22df489fda206139ecd63e2e9c04965"
   integrity sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==
@@ -4279,6 +4584,18 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     ethjs-util "^0.1.3"
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
+
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.7, ethereumjs-util@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
+  integrity sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
 
 ethereumjs-util@^7.0.2:
   version "7.0.7"
@@ -4542,6 +4859,11 @@ execa@^4.0.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -4876,7 +5198,7 @@ follow-redirects@^1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
   integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
-for-each@~0.3.3:
+for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
@@ -5321,15 +5643,20 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
-hardhat@^2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.0.5.tgz#e2fb4d55b11342ee6ac914ca2eddd755db8de94b"
-  integrity sha512-Q/lXZ1rMNq54GZMB7Ak+981vyXNjFuYzFMIEcCz8jDcY3RJn44yxhkCWN8ARAtCtbMfSIUIER1P1MBQQmdZyUQ==
+hardhat@^2.4.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.5.0.tgz#0a10bf85d9b2c3c7c12cfa4e35454296c670c054"
+  integrity sha512-S5CWcmiFZlFF2qFGyf5LlgVnJDXwTs5UBKU3GPQCjsUD3NAIWzXr/4xDSij3YWdg751axgLiKAJM01cHcxGb7A==
   dependencies:
-    "@nomiclabs/ethereumjs-vm" "^4.1.1"
+    "@ethereumjs/block" "^3.4.0"
+    "@ethereumjs/blockchain" "^5.4.0"
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/tx" "^3.3.0"
+    "@ethereumjs/vm" "^5.5.0"
+    "@ethersproject/abi" "^5.1.2"
     "@sentry/node" "^5.18.1"
-    "@solidity-parser/parser" "^0.7.1"
-    "@types/bn.js" "^4.11.5"
+    "@solidity-parser/parser" "^0.11.0"
+    "@types/bn.js" "^5.1.0"
     "@types/lru-cache" "^5.1.0"
     abort-controller "^3.0.0"
     adm-zip "^0.4.16"
@@ -5343,19 +5670,17 @@ hardhat@^2.0.3:
     eth-sig-util "^2.5.2"
     ethereum-cryptography "^0.1.2"
     ethereumjs-abi "^0.6.8"
-    ethereumjs-account "^3.0.0"
-    ethereumjs-block "^2.2.0"
-    ethereumjs-common "^1.5.0"
-    ethereumjs-tx "^2.1.1"
-    ethereumjs-util "^6.1.0"
+    ethereumjs-util "^7.1.0"
     find-up "^2.1.0"
     fp-ts "1.19.3"
     fs-extra "^7.0.1"
     glob "^7.1.3"
+    https-proxy-agent "^5.0.0"
     immutable "^4.0.0-rc.12"
     io-ts "1.10.4"
     lodash "^4.17.11"
-    merkle-patricia-tree "^3.0.0"
+    merkle-patricia-tree "^4.2.0"
+    mnemonist "^0.38.0"
     mocha "^7.1.2"
     node-fetch "^2.6.0"
     qs "^6.7.0"
@@ -5369,7 +5694,7 @@ hardhat@^2.0.3:
     "true-case-path" "^2.2.1"
     tsort "0.0.1"
     uuid "^3.3.2"
-    ws "^7.2.1"
+    ws "^7.4.6"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -5475,7 +5800,7 @@ hash.js@1.1.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -5498,7 +5823,7 @@ heap@0.2.6:
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
@@ -6393,6 +6718,11 @@ level-codec@~7.0.0:
   resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-7.0.1.tgz#341f22f907ce0f16763f24bddd681e395a0fb8a7"
   integrity sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==
 
+level-concat-iterator@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz#1d1009cf108340252cb38c51f9727311193e6263"
+  integrity sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==
+
 level-errors@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/level-errors/-/level-errors-1.1.2.tgz#4399c2f3d3ab87d0625f7e3676e2d807deff404d"
@@ -6442,6 +6772,15 @@ level-iterator-stream@~3.0.0:
     readable-stream "^2.3.6"
     xtend "^4.0.0"
 
+level-iterator-stream@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz#7ceba69b713b0d7e22fcc0d1f128ccdc8a24f79c"
+  integrity sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+    xtend "^4.0.2"
+
 level-mem@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/level-mem/-/level-mem-3.0.1.tgz#7ce8cf256eac40f716eb6489654726247f5a89e5"
@@ -6449,6 +6788,22 @@ level-mem@^3.0.1:
   dependencies:
     level-packager "~4.0.0"
     memdown "~3.0.0"
+
+level-mem@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/level-mem/-/level-mem-5.0.1.tgz#c345126b74f5b8aa376dc77d36813a177ef8251d"
+  integrity sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==
+  dependencies:
+    level-packager "^5.0.3"
+    memdown "^5.0.0"
+
+level-packager@^5.0.3:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/level-packager/-/level-packager-5.1.1.tgz#323ec842d6babe7336f70299c14df2e329c18939"
+  integrity sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==
+  dependencies:
+    encoding-down "^6.3.0"
+    levelup "^4.3.2"
 
 level-packager@~4.0.0:
   version "4.0.1"
@@ -6481,6 +6836,13 @@ level-sublevel@6.6.4:
     typewiselite "~1.0.0"
     xtend "~4.0.0"
 
+level-supports@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-1.0.1.tgz#2f530a596834c7301622521988e2c36bb77d122d"
+  integrity sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==
+  dependencies:
+    xtend "^4.0.2"
+
 level-ws@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/level-ws/-/level-ws-0.0.0.tgz#372e512177924a00424b0b43aef2bb42496d228b"
@@ -6496,6 +6858,15 @@ level-ws@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.8"
+    xtend "^4.0.1"
+
+level-ws@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/level-ws/-/level-ws-2.0.0.tgz#207a07bcd0164a0ec5d62c304b4615c54436d339"
+  integrity sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^3.1.0"
     xtend "^4.0.1"
 
 levelup@3.1.1, levelup@^3.0.0:
@@ -6519,6 +6890,17 @@ levelup@^1.2.1:
     level-iterator-stream "~1.3.0"
     prr "~1.0.1"
     semver "~5.4.1"
+    xtend "~4.0.0"
+
+levelup@^4.3.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/levelup/-/levelup-4.4.0.tgz#f89da3a228c38deb49c48f88a70fb71f01cafed6"
+  integrity sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==
+  dependencies:
+    deferred-leveldown "~5.3.0"
+    level-errors "~2.0.0"
+    level-iterator-stream "~4.0.0"
+    level-supports "~1.0.0"
     xtend "~4.0.0"
 
 leven@2.1.0:
@@ -6736,6 +7118,13 @@ math-random@^1.0.1:
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
   integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
+mcl-wasm@^0.7.1:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.8.tgz#4d0dc5a92f7bd20892fd3fcd41764acf86fd1e6e"
+  integrity sha512-qNHlYO6wuEtSoH5A8TcZfCEHtw8gGPqF6hLZpQn2SVd/Mck0ELIKOkmj072D98S9B9CI/jZybTUC96q1P2/ZDw==
+  dependencies:
+    typescript "^4.3.4"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6777,6 +7166,18 @@ memdown@^1.0.0:
     inherits "~2.0.1"
     ltgt "~2.2.0"
     safe-buffer "~5.1.1"
+
+memdown@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/memdown/-/memdown-5.1.0.tgz#608e91a9f10f37f5b5fe767667a8674129a833cb"
+  integrity sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==
+  dependencies:
+    abstract-leveldown "~6.2.1"
+    functional-red-black-tree "~1.0.1"
+    immediate "~3.2.3"
+    inherits "~2.0.1"
+    ltgt "~2.2.0"
+    safe-buffer "~5.2.0"
 
 memdown@~3.0.0:
   version "3.0.0"
@@ -6827,7 +7228,7 @@ merkle-lib@^2.0.10:
   resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
   integrity sha1-grjbrnXieneFOItz+ddyXQ9vMyY=
 
-merkle-patricia-tree@3.0.0, merkle-patricia-tree@^3.0.0:
+merkle-patricia-tree@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz#448d85415565df72febc33ca362b8b614f5a58f8"
   integrity sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==
@@ -6853,6 +7254,19 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     readable-stream "^2.0.0"
     rlp "^2.0.0"
     semaphore ">=1.0.1"
+
+merkle-patricia-tree@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-4.2.0.tgz#a204b9041be5c25e8d14f0ff47021de090e811a1"
+  integrity sha512-0sBVXs7z1Q1/kxzWZ3nPnxSPiaHKF/f497UQzt9O7isRcS10tel9jM/4TivF6Jv7V1yFq4bWyoATxbDUOen5vQ==
+  dependencies:
+    "@types/levelup" "^4.3.0"
+    ethereumjs-util "^7.0.10"
+    level-mem "^5.0.1"
+    level-ws "^2.0.0"
+    readable-stream "^3.6.0"
+    rlp "^2.2.4"
+    semaphore-async-await "^1.5.1"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -7033,6 +7447,13 @@ mkdirp@0.5.5, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mnemonist@^0.38.0:
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
+  dependencies:
+    obliterator "^1.6.1"
 
 mocha@^4.0.1:
   version "4.1.0"
@@ -7460,6 +7881,15 @@ object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
 
+object.getownpropertydescriptors@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
+  integrity sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -7474,6 +7904,11 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 oboe@2.1.4:
   version "2.1.4"
@@ -7952,6 +8387,11 @@ pretty-quick@^3.0.2:
     mri "^1.1.5"
     multimatch "^4.0.0"
 
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -8227,7 +8667,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.0.6, readable-stream@^3.5.0, readable-stream@^3.6.0:
+"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.0.6, readable-stream@^3.1.0, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -8625,6 +9065,11 @@ seek-bzip@^1.0.5:
   integrity sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==
   dependencies:
     commander "^2.8.1"
+
+semaphore-async-await@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz#857bef5e3644601ca4b9570b87e9df5ca12974fa"
+  integrity sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo=
 
 semaphore@>=1.0.1, semaphore@^1.0.3, semaphore@^1.1.0:
   version "1.1.0"
@@ -9650,6 +10095,11 @@ typeforce@^1.11.3, typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
+typescript@^4.3.4:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/typewise-core/-/typewise-core-1.2.0.tgz#97eb91805c7f55d2f941748fa50d315d991ef195"
@@ -9837,6 +10287,17 @@ util.promisify@^1.0.0:
     es-abstract "^1.17.2"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
+
+util.promisify@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.1.tgz#77832f57ced2c9478174149cae9b96e9918cd54b"
+  integrity sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    for-each "^0.3.3"
+    has-symbols "^1.0.1"
+    object.getownpropertydescriptors "^2.1.1"
 
 util@^0.12.0:
   version "0.12.3"
@@ -11077,15 +11538,15 @@ ws@^5.1.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.2.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.1.tgz#a333be02696bd0e54cea0434e21dcc8a9ac294bb"
-  integrity sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==
-
 ws@^7.4.2:
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
   integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
+
+ws@^7.4.6:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 xhr-request-promise@^0.1.2:
   version "0.1.3"
@@ -11129,7 +11590,7 @@ xmlhttprequest@1.8.0:
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
   integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
This PR adds a `MEVBriber.sol` contract and corresponding `harvest_flashbots.py` script which is used to route strategy `harvest()` transactions directly to miners through Flashbots. This makes harvesting resistant to front-running sandwich attacks. 

The briber is only used for strategies that swap tokens in the `harvest()` call.

```
Convex:
StrategyConvexStakingOptimizer.sol
StrategyCvxCrvHelper.sol
StrategyCvxHelper.sol

Curve:
StrategyCurveGaugeBase.sol

PancakeSwap:
StrategyPancakeLpOptimizer.sol

Uniswap:
StrategyBadgerLpMetaFarm.sol
StrategyDiggLpMetaFarm.sol

Unit Protocol
StrategyUnitProtocolRenbtc.sol
```

TODOs/Blockers:
1. Currently only supports `StrategyBadgerLpMetaFarm.sol`. Add support for others
2. Add price/swap API which contains BADGER prices
3. Write deployment and local testing script (see how Flashbots transactions can be locally tested)
4. Add script keeper account as keeper of `MEVBriber`
5. Increase miner bribe slowly until transaction is included